### PR TITLE
Adding Contributors-Readme-Action

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -66,7 +66,13 @@ Si no te quieres perder nada de lo que estamos construyendo, aquí te dejo donde
 - 🏠 **[Discord](https://discord.gg/Qncuxgcgsn):** Aquí te podrás enterar de todo… como dije antes este es “Nuestro Centro de Operaciones”, toda la magia ocurre aquí.
 
 
----
+-----
+
+<!-- readme: contributors -start -->
+
+<!-- readme: contributors -end -->
+
+-----
 
 
 Creado con ❤️ por [Serudda](https://www.twitter.com/serudda)

--- a/workflows/main.yml
+++ b/workflows/main.yml
@@ -1,0 +1,15 @@
+# This YAML code defines a workflow that runs when the main branch is pushed to
+on:
+    push:
+        branches:
+            - main # The name of the branch to trigger the workflow
+
+jobs:
+    contrib-readme-job: # The name of the job
+        runs-on: ubuntu-latest # The type of machine to run the job on
+        name: A job to automate contrib in readme # A human-readable name for the job
+        steps: # The list of steps to perform in the job
+            - name: Contribute List # The name of the first step
+              uses: akhilmhdh/contributors-readme-action@v2.3.6 # The action to use in this step
+              env: # The environment variables to pass to the action
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # The GitHub token to authenticate with


### PR DESCRIPTION
- Contributors-Readme-Action is a simple GitHub action to automate contributors list in README file. Not only contributors, collborators, bots or any user.

- As it uses a GitHub action it's secure and very easy to integrate into your projects. Once added it will automatically add all the repository contributors to your readme in a well-formatted table, including future contributors.

- The contributors list is fetched from [GitHub API](https://developer.github.com/v3/repos/statistics/).

Here the documentation about 👉 [Contributors-Readme-Action](https://github.com/marketplace/actions/contribute-list?version=v2.3.6)